### PR TITLE
Update ContextDragBehavior.cs

### DIFF
--- a/src/Avalonia.Xaml.Interactions.DragAndDrop/ContextDragBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.DragAndDrop/ContextDragBehavior.cs
@@ -136,6 +136,7 @@ public class ContextDragBehavior : Behavior<Control>
             if (e.Source is Control control
                 && AssociatedObject?.DataContext == control.DataContext)
             {
+                if ((control as ISelectable ?? control.Parent as ISelectable)?.IsSelected ?? false) e.Handled = true; //avoid deselection on drag
                 _dragStartPoint = e.GetPosition(null);
                 _triggerEvent = e;
                 _lock = true;


### PR DESCRIPTION
Fixes an issue where there is a multi-item selection in `ListBox` control which gets cleared when this behavior is attached to a `ListItem`